### PR TITLE
Fill From Template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.19)
 
 project(
-  MyMkdir
-  VERSION 0.0.0
-  DESCRIPTION "A starter CMake package for creating directories recursively"
-  HOMEPAGE_URL https://github.com/threeal/cmake-starter
+  CheckCoverage
+  VERSION 0.1.0
+  DESCRIPTION "Check for test coverage in your CMake project"
+  HOMEPAGE_URL https://github.com/threeal/CheckCoverage.cmake
   LANGUAGES NONE
 )
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-This is free and unencumbered software released into the public domain.
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2024 Alfi Maulana
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <http://unlicense.org/>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,8 @@
-<!-- Clear the content of this file and replace it with the description of your project. -->
-<!-- Learn more: https://www.makeareadme.com -->
+# CheckCoverage.cmake
 
-# CMake Starter
+[![version](https://img.shields.io/github/v/release/threeal/CheckCoverage.cmake?style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/releases)
+[![license](https://img.shields.io/github/license/threeal/CheckCoverage.cmake?style=flat-square)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/CheckCoverage.cmake/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/actions/workflows/build.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/CheckCoverage.cmake/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/actions/workflows/test.yaml)
 
-[![version](https://img.shields.io/github/v/release/threeal/cmake-starter?style=flat-square)](https://github.com/threeal/cmake-starter/releases)
-[![license](https://img.shields.io/github/license/threeal/cmake-starter?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/cmake-starter/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/cmake-starter/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/cmake-starter/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/cmake-starter/actions/workflows/test.yaml)
-
-The CMake Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [CMake](https://cmake.org/) project.
-This template offers a streamlined foundation, complete with predefined file structures, essential tools, and recommended settings, ensuring a swift and efficient start to your CMake development journey.
-
-## Key Features
-
-- Standard template for CMake projects supporting installation and testing of CMake modules.
-- Automated CI with [GitHub Actions](https://github.com/features/actions) workflows for building and testing the CMake project.
-- [Dependabot](https://docs.github.com/en/code-security/dependabot) integration for checking updates on GitHub Actions dependencies.
-
-## Usage
-
-Refer to [this wiki](https://github.com/threeal/cmake-starter/wiki) for information on how to use this template.
+CheckCoverage.cmake is a [CMake](https://cmake.org/) module that provides utility functions for checking test coverage in your CMake project.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,9 @@
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/CheckCoverage.cmake/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/actions/workflows/test.yaml)
 
 CheckCoverage.cmake is a [CMake](https://cmake.org/) module that provides utility functions for checking test coverage in your CMake project.
+
+## License
+
+This project is licensed under the terms of the [MIT License](./LICENSE).
+
+Copyright © 2024 [Alfi Maulana](https://github.com/threeal)


### PR DESCRIPTION
This pull request fills the following stuffs:
- `LICENSE`: replaces the license with an MIT license.
- `README.md`: fills the project description and adds a license section.
- `CMakeLists.txt`: fills the project information.