### PR TITLE
Run Test Workflow on Ubuntu and Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,11 @@ on:
 jobs:
   test-project:
     name: Test Project
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1

--- a/test/BuildSampleTest.cmake
+++ b/test/BuildSampleTest.cmake
@@ -36,6 +36,7 @@ function(test_sample)
   find_program(CTEST_PROGRAM ctest REQUIRED)
   execute_process(
     COMMAND ${CTEST_PROGRAM}
+      -C debug
       --test-dir ${CMAKE_CURRENT_LIST_DIR}/sample/build
       --no-tests=error
     RESULT_VARIABLE RES


### PR DESCRIPTION
This pull request resolves #4 by running the `test` workflow on the Ubuntu and Windows runners. It also fixes failed workflow run on Windows caused by wrong command for testing the sample project.