### PR TITLE
Check Test Coverage in Sample Project

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Install Dependencies
+        uses: pipx install gcovr
+
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:

--- a/test/BuildSampleTest.cmake
+++ b/test/BuildSampleTest.cmake
@@ -45,11 +45,26 @@ function(test_sample)
   endif()
 endfunction()
 
+function(check_sample_test_coverage)
+  message(STATUS "Checking sample project test coverage")
+  find_program(GCOVR_PROGRAM gcovr REQUIRED)
+  execute_process(
+    COMMAND ${GCOVR_PROGRAM}
+      --root ${CMAKE_CURRENT_LIST_DIR}/sample
+      --fail-under-line 100
+    RESULT_VARIABLE RES
+  )
+  if(NOT RES EQUAL 0)
+    message(FATAL_ERROR "Failed to check sample project test coverage")
+  endif()
+endfunction()
+
 if("Build sample project" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   configure_sample()
   build_sample()
   test_sample()
+  check_sample_test_coverage()
 endif()
 
 if(TEST_COUNT LESS_EQUAL 0)

--- a/test/sample/CMakeLists.txt
+++ b/test/sample/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(Sample)
 
+add_compile_options(--coverage -O0)
+add_link_options(--coverage)
+
 add_library(fibonacci src/fibonacci.cpp)
 target_include_directories(fibonacci PUBLIC include)
 


### PR DESCRIPTION
This pull request resolves #6 by introducing the following changes during sample project testing:
- Appends coverage flags to the compile and link options in the sample project.
- Adds a step to check test coverage using [gcovr ](https://gcovr.com/en/stable/) after testing the sample project.
- Adds a step for installing gcovr in the `test-project` job of the `test` workflow.