### PR TITLE
Add Check Coverage Function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT SUBPROJECT)
 
   install(
     FILES
+      cmake/CheckCoverage.cmake
       cmake/MkdirRecursive.cmake
       cmake/MyMkdirConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/MyMkdirConfigVersion.cmake

--- a/cmake/CheckCoverage.cmake
+++ b/cmake/CheckCoverage.cmake
@@ -1,0 +1,29 @@
+# This code is licensed under the terms of the MIT License.
+# Copyright (c) 2024 Alfi Maulana
+
+include_guard(GLOBAL)
+
+# Function to enable test coverage check on a specific target.
+# Arguments:
+#   - TARGET: The target for which to enable test coverage check.
+function(target_check_coverage TARGET)
+  if(MSVC)
+    message(WARNING "Test coverage check is not available on MSVC")
+    return()
+  endif()
+
+  # Append options for enabling test coverage check.
+  target_compile_options(${TARGET} PRIVATE --coverage -O0 -fno-exceptions)
+  target_link_options(${TARGET} PRIVATE --coverage)
+
+  # Remove GCDA files every time the target is relinked.
+  get_target_property(TARGET_BINARY_DIR ${TARGET} BINARY_DIR)
+  get_target_property(TARGET_SOURCES ${TARGET} SOURCES)
+  foreach(SOURCE ${TARGET_SOURCES})
+    set(GCDA ${TARGET_BINARY_DIR}/CMakeFiles/${TARGET}.dir/${SOURCE}.gcda)
+    add_custom_command(
+      TARGET ${TARGET} PRE_LINK
+      COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
+    )
+  endforeach()
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,6 @@ function(add_cmake_test FILE)
 endfunction()
 
 add_cmake_test(
-  BuildSampleTest.cmake
-  "Build sample project"
+  CheckCoverageTest.cmake
+  "Check test coverage"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,4 +13,5 @@ endfunction()
 add_cmake_test(
   CheckCoverageTest.cmake
   "Check test coverage"
+  "Check test coverage without coverage flags"
 )

--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -6,11 +6,16 @@ endif()
 set(TEST_COUNT 0)
 
 function(configure_sample)
+  cmake_parse_arguments(ARG "WITHOUT_COVERAGE_FLAGS" "" "" ${ARGN})
   message(STATUS "Configuring sample project")
+  if(ARG_WITHOUT_COVERAGE_FLAGS)
+    list(APPEND CONFIGURE_ARGS -D WITHOUT_COVERAGE_FLAGS=TRUE)
+  endif()
   execute_process(
     COMMAND ${CMAKE_COMMAND}
       -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
       -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+      ${CONFIGURE_ARGS}
       --fresh
       ${CMAKE_CURRENT_LIST_DIR}/sample
     RESULT_VARIABLE RES
@@ -47,6 +52,8 @@ function(test_sample)
 endfunction()
 
 function(check_sample_test_coverage)
+  cmake_parse_arguments(ARG SHOULD_FAIL "" "" ${ARGN})
+
   message(STATUS "Getting sample project build information")
   execute_process(
     COMMAND ${CMAKE_COMMAND} -L -N ${CMAKE_CURRENT_LIST_DIR}/sample/build
@@ -68,7 +75,9 @@ function(check_sample_test_coverage)
       --fail-under-line 100
     RESULT_VARIABLE RES
   )
-  if(NOT RES EQUAL 0)
+  if(ARG_SHOULD_FAIL AND RES EQUAL 0)
+    message(FATAL_ERROR "Sample project test coverage check should be failed")
+  elseif(NOT ARG_SHOULD_FAIL AND NOT RES EQUAL 0)
     message(FATAL_ERROR "Failed to check sample project test coverage")
   endif()
 endfunction()
@@ -79,6 +88,14 @@ if("Check test coverage" MATCHES ${TEST_MATCHES})
   build_sample()
   test_sample()
   check_sample_test_coverage()
+endif()
+
+if("Check test coverage without coverage flags" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+  configure_sample(WITHOUT_COVERAGE_FLAGS)
+  build_sample()
+  test_sample()
+  check_sample_test_coverage(SHOULD_FAIL)
 endif()
 
 if(TEST_COUNT LESS_EQUAL 0)

--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -73,7 +73,7 @@ function(check_sample_test_coverage)
   endif()
 endfunction()
 
-if("Build sample project" MATCHES ${TEST_MATCHES})
+if("Check test coverage" MATCHES ${TEST_MATCHES})
   math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
   configure_sample()
   build_sample()

--- a/test/sample/CMakeLists.txt
+++ b/test/sample/CMakeLists.txt
@@ -7,16 +7,17 @@ if(MSVC)
   set(MSVC ${MSVC} CACHE BOOL "")
 endif()
 
-add_compile_options(--coverage -O0)
-add_link_options(--coverage)
+include(CheckCoverage)
 
 add_library(fibonacci src/fibonacci.cpp)
 target_include_directories(fibonacci PUBLIC include)
+target_check_coverage(fibonacci)
 
 enable_testing()
 
 add_executable(fibonacci_test test/fibonacci_test.cpp)
 target_link_libraries(fibonacci_test PRIVATE fibonacci)
+target_check_coverage(fibonacci_test)
 
 add_test(
   NAME fibonacci_test

--- a/test/sample/CMakeLists.txt
+++ b/test/sample/CMakeLists.txt
@@ -11,13 +11,17 @@ include(CheckCoverage)
 
 add_library(fibonacci src/fibonacci.cpp)
 target_include_directories(fibonacci PUBLIC include)
-target_check_coverage(fibonacci)
+if(NOT WITHOUT_COVERAGE_FLAGS)
+  target_check_coverage(fibonacci)
+endif()
 
 enable_testing()
 
 add_executable(fibonacci_test test/fibonacci_test.cpp)
 target_link_libraries(fibonacci_test PRIVATE fibonacci)
-target_check_coverage(fibonacci_test)
+if(NOT WITHOUT_COVERAGE_FLAGS)
+  target_check_coverage(fibonacci_test)
+endif()
 
 add_test(
   NAME fibonacci_test


### PR DESCRIPTION
This pull request resolves #8 by introducing the following changes:
- Adds a `CheckCoverage.cmake` module that contains a `target_check_coverage` function.
- Modifies the `BuildSampleTest.cmake` test module as follows:
  - Renames to `CheckCoverageTest.cmake`.
  - Renames the test cases.
  - Utilizes the `target_check_coverage` function in the sample project.
  - Adds a test case for checking test coverage without coverage flags enabled.