### PR TITLE
Fix Failing Test Workflow Caused by Incorrect Configuration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install Dependencies
-        uses: pipx install gcovr
+        run: pipx install gcovr
 
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0


### PR DESCRIPTION
This pull request resolves #10 by fixing typo in the `Install Dependencies` step of the `Test Project` job.