### PR TITLE
Skip Test Coverage Check on MSVC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Install Dependencies
+      - name: Install gcovr
         if: matrix.os != 'windows'
         run: pipx install gcovr
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install Dependencies
+        if: matrix.os != 'windows'
         run: pipx install gcovr
 
       - name: Configure Project

--- a/test/BuildSampleTest.cmake
+++ b/test/BuildSampleTest.cmake
@@ -47,6 +47,19 @@ function(test_sample)
 endfunction()
 
 function(check_sample_test_coverage)
+  message(STATUS "Getting sample project build information")
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -L -N ${CMAKE_CURRENT_LIST_DIR}/sample/build
+    OUTPUT_VARIABLE OUT
+  )
+  string(REPLACE "\n" ";" VARS ${OUT})
+  foreach(VAR ${VARS})
+    if(VAR STREQUAL MSVC:BOOL=1)
+      message(WARNING "Skipping sample project test coverage check on MSVC")
+      return()
+    endif()
+  endforeach()
+
   message(STATUS "Checking sample project test coverage")
   find_program(GCOVR_PROGRAM gcovr REQUIRED)
   execute_process(

--- a/test/sample/CMakeLists.txt
+++ b/test/sample/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.5)
 
 project(Sample)
 
+# Add information to the CMake cache if it is built on MSVC.
+if(MSVC)
+  set(MSVC ${MSVC} CACHE BOOL "")
+endif()
+
 add_compile_options(--coverage -O0)
 add_link_options(--coverage)
 


### PR DESCRIPTION
This pull request resolves #12 by introducing the following changes:
- Skips the sample project test coverage check during testing on the MSVC compiler.
- Renames the "Install Dependencies" step in the Test workflow to "Install gcovr".
- Skip the "Install gcovr" step on the Windows runner.