### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # CheckCoverage.cmake
 
-[![version](https://img.shields.io/github/v/release/threeal/CheckCoverage.cmake?style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/releases)
-[![license](https://img.shields.io/github/license/threeal/CheckCoverage.cmake?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/CheckCoverage.cmake/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/CheckCoverage.cmake/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/CheckCoverage.cmake/actions/workflows/test.yaml)
-
 CheckCoverage.cmake is a [CMake](https://cmake.org/) module that provides utility functions for checking test coverage in your CMake project.
 
 ## License


### PR DESCRIPTION
This pull request resolves #22 by simply removing badges from the `README.md` file.