### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 function(configure_sample)
   cmake_parse_arguments(ARG "WITHOUT_COVERAGE_FLAGS" "" "" ${ARGN})
   message(STATUS "Configuring sample project")


### PR DESCRIPTION
This pull request resolves #37 by simply specifying the CMake minimum required version in the test modules.