### PR TITLE
Improve Function Arguments Handling

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,11 @@
 function(add_cmake_test FILE)
-  foreach(NAME ${ARGN})
+  math(EXPR STOP "${ARGC} - 1")
+  foreach(I RANGE 1 "${STOP}")
     add_test(
-      NAME "${NAME}"
+      NAME "${ARGV${I}}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${NAME}
+        -D "TEST_COMMAND=${ARGV${I}}"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 function(configure_sample)
-  cmake_parse_arguments(ARG "WITHOUT_COVERAGE_FLAGS" "" "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG WITHOUT_COVERAGE_FLAGS "" "")
   message(STATUS "Configuring sample project")
   if(ARG_WITHOUT_COVERAGE_FLAGS)
     list(APPEND CONFIGURE_ARGS -D WITHOUT_COVERAGE_FLAGS=TRUE)
@@ -47,7 +47,7 @@ function(test_sample)
 endfunction()
 
 function(check_sample_test_coverage)
-  cmake_parse_arguments(ARG SHOULD_FAIL "" "" ${ARGN})
+  cmake_parse_arguments(PARSE_ARGV 0 ARG SHOULD_FAIL "" "")
 
   message(STATUS "Getting sample project build information")
   execute_process(


### PR DESCRIPTION
This pull request resolves #39 by introducing the following changes:
- Utilizes the `ARGC` and `ARGV<INDEX>` variables in the `add_cmake_test` function.
- Utilizes the `PARSE_ARGV` version of the `cmake_parse_arguments` function, replacing the standard usage which utilized `ARGN`.