### PR TITLE
Bump Assertion.cmake to Version 0.3.0

### DIFF
--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -8,65 +8,68 @@ include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 function(configure_sample)
   cmake_parse_arguments(PARSE_ARGV 0 ARG WITHOUT_COVERAGE_FLAGS "" "")
-  message(STATUS "Configuring sample project")
-  if(ARG_WITHOUT_COVERAGE_FLAGS)
-    list(APPEND CONFIGURE_ARGS -D WITHOUT_COVERAGE_FLAGS=TRUE)
-  endif()
-  assert_execute_process(
-    "${CMAKE_COMMAND}"
-      -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
-      -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-      ${CONFIGURE_ARGS}
-      --fresh
-      ${CMAKE_CURRENT_LIST_DIR}/sample)
+  section("configure sample project")
+    if(ARG_WITHOUT_COVERAGE_FLAGS)
+      list(APPEND CONFIGURE_ARGS -D WITHOUT_COVERAGE_FLAGS=TRUE)
+    endif()
+    assert_execute_process(
+      "${CMAKE_COMMAND}"
+        -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
+        -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+        ${CONFIGURE_ARGS}
+        --fresh
+        ${CMAKE_CURRENT_LIST_DIR}/sample)
+  endsection()
 endfunction()
 
 function(build_sample)
-  message(STATUS "Building sample project")
-  assert_execute_process(
-    "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build)
+  section("build sample project")
+    assert_execute_process(
+      "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build)
+  endsection()
 endfunction()
 
 function(test_sample)
-  message(STATUS "Testing sample project")
-  find_program(CTEST_PROGRAM ctest REQUIRED)
-  assert_execute_process(
-    "${CTEST_PROGRAM}"
-      -C debug
-      --test-dir ${CMAKE_CURRENT_LIST_DIR}/sample/build
-      --no-tests=error)
+  section("test sample project")
+    find_program(CTEST_PROGRAM ctest REQUIRED)
+    assert_execute_process(
+      "${CTEST_PROGRAM}"
+        -C debug
+        --test-dir ${CMAKE_CURRENT_LIST_DIR}/sample/build
+        --no-tests=error)
+  endsection()
 endfunction()
 
 function(check_sample_test_coverage)
   cmake_parse_arguments(PARSE_ARGV 0 ARG SHOULD_FAIL "" "")
 
-  message(STATUS "Getting sample project build information")
-  execute_process(
-    COMMAND "${CMAKE_COMMAND}" -L -N ${CMAKE_CURRENT_LIST_DIR}/sample/build
-    OUTPUT_VARIABLE OUT
-  )
-  string(REPLACE "\n" ";" VARS "${OUT}")
-  foreach(VAR ${VARS})
-    if(VAR STREQUAL MSVC:BOOL=1)
-      message(WARNING "Skipping sample project test coverage check on MSVC")
-      return()
-    endif()
-  endforeach()
+  section("check sample project test coverage")
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -L -N ${CMAKE_CURRENT_LIST_DIR}/sample/build
+      OUTPUT_VARIABLE OUT
+    )
+    string(REPLACE "\n" ";" VARS "${OUT}")
+    foreach(VAR ${VARS})
+      if(VAR STREQUAL MSVC:BOOL=1)
+        message(WARNING "skipp sample project test coverage check on MSVC")
+        return()
+      endif()
+    endforeach()
 
-  message(STATUS "Checking sample project test coverage")
-  find_program(GCOVR_PROGRAM gcovr REQUIRED)
-  if(ARG_SHOULD_FAIL)
-    assert_execute_process(
-      COMMAND "${GCOVR_PROGRAM}"
-        --root ${CMAKE_CURRENT_LIST_DIR}/sample
-        --fail-under-line 100
-      ERROR "failed minimum line coverage")
-  else()
-    assert_execute_process(
-      "${GCOVR_PROGRAM}"
-        --root ${CMAKE_CURRENT_LIST_DIR}/sample
-        --fail-under-line 100)
-  endif()
+    find_program(GCOVR_PROGRAM gcovr REQUIRED)
+    if(ARG_SHOULD_FAIL)
+      assert_execute_process(
+        COMMAND "${GCOVR_PROGRAM}"
+          --root ${CMAKE_CURRENT_LIST_DIR}/sample
+          --fail-under-line 100
+        ERROR "failed minimum line coverage")
+    else()
+      assert_execute_process(
+        "${GCOVR_PROGRAM}"
+          --root ${CMAKE_CURRENT_LIST_DIR}/sample
+          --fail-under-line 100)
+    endif()
+  endsection()
 endfunction()
 
 function("Check test coverage")

--- a/test/CheckCoverageTest.cmake
+++ b/test/CheckCoverageTest.cmake
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 file(
-  DOWNLOAD https://threeal.github.io/assertion-cmake/v0.2.0
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v0.3.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/Assertion.cmake
-  EXPECTED_MD5 4ee0e5217b07442d1a31c46e78bb5fac)
+  EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
 include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
 function(configure_sample)
@@ -13,31 +13,28 @@ function(configure_sample)
     list(APPEND CONFIGURE_ARGS -D WITHOUT_COVERAGE_FLAGS=TRUE)
   endif()
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}"
+    "${CMAKE_COMMAND}"
       -B ${CMAKE_CURRENT_LIST_DIR}/sample/build
       -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
       ${CONFIGURE_ARGS}
       --fresh
-      ${CMAKE_CURRENT_LIST_DIR}/sample
-  )
+      ${CMAKE_CURRENT_LIST_DIR}/sample)
 endfunction()
 
 function(build_sample)
   message(STATUS "Building sample project")
   assert_execute_process(
-    COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build
-  )
+    "${CMAKE_COMMAND}" --build ${CMAKE_CURRENT_LIST_DIR}/sample/build)
 endfunction()
 
 function(test_sample)
   message(STATUS "Testing sample project")
   find_program(CTEST_PROGRAM ctest REQUIRED)
   assert_execute_process(
-    COMMAND "${CTEST_PROGRAM}"
+    "${CTEST_PROGRAM}"
       -C debug
       --test-dir ${CMAKE_CURRENT_LIST_DIR}/sample/build
-      --no-tests=error
-  )
+      --no-tests=error)
 endfunction()
 
 function(check_sample_test_coverage)
@@ -63,14 +60,12 @@ function(check_sample_test_coverage)
       COMMAND "${GCOVR_PROGRAM}"
         --root ${CMAKE_CURRENT_LIST_DIR}/sample
         --fail-under-line 100
-      ERROR "failed minimum line coverage"
-    )
+      ERROR "failed minimum line coverage")
   else()
     assert_execute_process(
-      COMMAND "${GCOVR_PROGRAM}"
+      "${GCOVR_PROGRAM}"
         --root ${CMAKE_CURRENT_LIST_DIR}/sample
-        --fail-under-line 100
-    )
+        --fail-under-line 100)
   endif()
 endfunction()
 


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [0.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v0.3.0). It also modifies tests to utilize the `section` function for debugging the current test section that is running.