### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: CHECK_COVERAGE_ENABLE_TESTS=ON
 
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,13 @@ project(
   LANGUAGES NONE
 )
 
+option(CHECK_COVERAGE_ENABLE_TESTS "Enable test targets.")
 option(CHECK_COVERAGE_ENABLE_INSTALL "Enable install targets."
   "${PROJECT_IS_TOP_LEVEL}")
 
 include(cmake/CheckCoverage.cmake)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(CHECK_COVERAGE_ENABLE_TESTS)
   enable_testing()
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
This pull request resolves #51 by adding a `CHECK_COVERAGE_ENABLE_TESTS` option to enable test targets in the project, replacing the `BUILD_TESTING` variable.