### PR TITLE
Utilize Pipx Install Action in Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,9 @@ jobs:
 
       - name: Install gcovr
         if: matrix.os != 'windows'
-        run: pipx install gcovr
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: gcovr
 
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0


### PR DESCRIPTION
This pull request resolves #56 by modifying the "Install gcovr" step in the `test.yaml` workflow to use the Pipx Install Action for installing `gcovr`.